### PR TITLE
check for all necessary software at once, enhanced README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,19 @@ Colibre is the default icon theme for LibreOffice in Windows as well as in Libre
 ## Install
 ### From extension
 
-Since Libreoffice 6.0, you can install an icon pack with an extension. To do that, simply clone the repository and generate the extension with the build script at the root of the project:
+Since Libreoffice 6.0, you can install an icon pack with an extension. To do that, simply clone the repository and generate the extension with the build script at the root of the project.
 
-Open it with Libreoffice or, open __Tools__ → __Extension Manager__ (or __Ctrl__ + __Alt__ + __E__) then click on __Add__ and browse for local directory where the extension placed (under build subdirectory).
+### Building the icon set
+Execute either the `build.sh` or `build-lightonly.sh` (for light icons only) script and make sure, that the following packages are installed:
+- optipng
+- svgcleaner
+- inkscape
+
+
+After that, open the desired .oxt file from withing the build folder with Libreoffice or, open __Tools__ → __Extension Manager__ (or __Ctrl__ + __Alt__ + __E__) then click on __Add__ and browse for local directory where the extension placed (under build subdirectory).
+
+---
+
 ### From script
 
 ⚠ Installing from script do not work when using a confined version of Libreoffice (like snap packages), in that case you must use the extension.

--- a/build-lightonly.sh
+++ b/build-lightonly.sh
@@ -1,17 +1,32 @@
 #!/bin/bash
 #2020 by Rizal Muttaqin
 
+# check if needed software is available to the system
+prerequisites=true
+
 if ! command -v optipng >/dev/null
 then
     echo "Please install optipng"
-    exit 1
+    prerequisites=false
 fi
 
 if ! command -v svgcleaner >/dev/null
 then
     echo "Please install svgcleaner"
-    exit 1
+    prerequisites=false
 fi
+
+if ! command -v inkscape >/dev/null
+then
+    echo "Please install inkscape"
+    prerequisites=false
+fi
+
+# Exit if one or more packages are missing
+if [[ $prerequisites == false ]]; then
+  exit 1
+fi
+
 
 echo "=> Remove old PNG version"
 cp "colibre/links.txt" \

--- a/build.sh
+++ b/build.sh
@@ -4,16 +4,30 @@
 links_light="colibre_svg/links.txt"
 links_dark="colibre_dark_svg/links.txt"
 
+# check if needed software is available to the system
+prerequisites=true
+
 if ! command -v optipng >/dev/null
 then
     echo "Please install optipng"
-    exit 1
+    prerequisites=false
 fi
 
 if ! command -v svgcleaner >/dev/null
 then
     echo "Please install svgcleaner"
-    exit 1
+    prerequisites=false
+fi
+
+if ! command -v inkscape >/dev/null
+then
+    echo "Please install inkscape"
+    prerequisites=false
+fi
+
+# Exit if one or more packages are missing
+if [[ $prerequisites == false ]]; then
+  exit 1
 fi
 
 echo "=> Remove old both light and dark version"


### PR DESCRIPTION
Hey there, thanks for your icon repository for libreoffice, finally my poor eyes can see pretty icons with dark mode! I was building the icon set myself, but had to rerun the build.sh three times individually because I lacked the dependencies (and did not check the build.sh). So my addition checks for all of those (inlcuding inkscape, which was somehow necessary, but not installed on my mint desktop) and aborts if necessary after all have been checked.
I also added some minor additional details to the README.md, listing the prerequisites.